### PR TITLE
Update for .NET5.0

### DIFF
--- a/DotnetTemplate.Web.Tests/DotnetTemplate.Web.Tests.csproj
+++ b/DotnetTemplate.Web.Tests/DotnetTemplate.Web.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>

--- a/DotnetTemplate.Web/.config/dotnet-tools.json
+++ b/DotnetTemplate.Web/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-ef": {
-      "version": "3.1.6",
+      "version": "5.0.3",
       "commands": [
         "dotnet-ef"
       ]

--- a/DotnetTemplate.Web/DotnetTemplate.Web.csproj
+++ b/DotnetTemplate.Web/DotnetTemplate.Web.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/DotnetTemplate.Web/DotnetTemplate.Web.csproj
+++ b/DotnetTemplate.Web/DotnetTemplate.Web.csproj
@@ -19,9 +19,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="3.1.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="5.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.2.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.2" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="5.0.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />
   </ItemGroup>
 

--- a/before_you_start.md
+++ b/before_you_start.md
@@ -7,4 +7,4 @@ You will need to have installed the following:
     - Make sure you have the [C# extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp)
 - [Git](https://git-scm.com/)
 - [NPM](https://www.npmjs.com/get-npm)
-- [.NET Core 3.1](https://dotnet.microsoft.com/download)
+- [.NET 5.0 (SDK)](https://dotnet.microsoft.com/download)


### PR DESCRIPTION
Updating the instructions and target frameworks to .NET 5.0

Tested on my own solution and locally/Jenkins/Github all able to still run dotnet build/dotnet test successfully (if specifying appropriate docker image, dotnet version)

Will separately raise a PR for updating the model answer

Merging this should probably be synced with Module 8 (which I need to raise a separate PR for) to avoid insisting on two different SDKS